### PR TITLE
Feature/ethui 206 fix null characters and percent

### DIFF
--- a/src/Decoder/index.ts
+++ b/src/Decoder/index.ts
@@ -104,8 +104,8 @@ autoScroll.setWheelListener();
 
 const calcPercentProgress = () => {
   const { totalFrames = 0 } = framesOpts || {};
-  const readedFrames = Object.keys(frames).length;
-  const percent = (readedFrames / totalFrames) * 100;
+  const readFrames = Object.keys(frames).length;
+  const percent = (readFrames / totalFrames) * 100;
 
   percentProgressEl.innerText = `${percent.toFixed(2)}%`;
 };

--- a/src/Decoder/index.ts
+++ b/src/Decoder/index.ts
@@ -140,9 +140,25 @@ const setParsedFrames = (data: FramesType) => {
       ? uint8ArrayToString(decompress(buffer))
       : buffer.toString()
   );
+  // HEADER decoding:
   const fileNameSize = result.readUInt8(0);
-  const filename = result.slice(1, fileNameSize + 1).toString();
-  setResult({ filename, data: result.slice(fileNameSize + 1).toString() });
+  const filename = result.subarray(1, fileNameSize + 1).toString();
+  // similar to filename - decode length of stringified file length and then file length itself
+  const dataLengthSize = result.readUInt8(fileNameSize + 1);
+  const dataLength = Number.parseInt(
+    result
+      .subarray(fileNameSize + 2, fileNameSize + dataLengthSize + 2)
+      .toString()
+  );
+  setResult({
+    filename,
+    data: result
+      .subarray(
+        fileNameSize + dataLengthSize + 2,
+        fileNameSize + dataLengthSize + 2 + dataLength
+      )
+      .toString(),
+  });
   ac.stop();
 };
 

--- a/src/Decoder/index.ts
+++ b/src/Decoder/index.ts
@@ -285,8 +285,8 @@ const updateCurrentBuffer = (currentBuffer: Buffer) => {
     if (!framesOpts) {
       framesOpts = opts;
     }
-    calcPercentProgress();
     tryProcessBlock(currentFrameIdx, currentBuffer.slice(8), opts);
+    calcPercentProgress();
   }
 
   autoScroll.scrollToElement();

--- a/src/Encoder/index.ts
+++ b/src/Encoder/index.ts
@@ -173,7 +173,7 @@ const compressPayload = (payload: string): Uint8Array => {
   return COMPRESS_PAYLOAD ? compress(Buffer.from(payload)) : Buffer.from(payload);
 };
 
-const solmonReedChunks = (
+const solomonReedChunks = (
   chunks: Uint8Array[],
   {
     blocksCount,
@@ -283,9 +283,10 @@ const encode = async () => {
   const parts = stringToChunks(compressedPayload, CHUNK_SIZE);
   await addLog(`Chunks before: ${parts.length}`);
   setGifProgress(50);
-  const chunks = solmonReedChunks(parts, { blocksCount, extraBlocksCount }).map(
-    (chunk, index) => ({ chunk, index })
-  );
+  const chunks = solomonReedChunks(parts, {
+    blocksCount,
+    extraBlocksCount,
+  }).map((chunk, index) => ({ chunk, index }));
   await addLog(`Chunks count: ${chunks.length}`);
   setGifProgress(100);
 

--- a/src/Encoder/index.ts
+++ b/src/Encoder/index.ts
@@ -268,9 +268,13 @@ const encode = async () => {
     ((BLOCKS_COUNT * Number(encoderErrorCorrection)) / 100) | 0;
   await addLog(`Filename: ${filename || ""}`);
   await addLog(`extraBlocksCount ${extraBlocksCount}`);
+  const stringData = encoderData.toString();
+  // pack into header filename and file length with their data length(uint8)
   const fileNameHeader = Buffer.concat([
     Buffer.from([filename ? filename.length : 0]),
     Buffer.from(filename || ""),
+    Buffer.from([stringData.length.toString().length]),
+    Buffer.from(stringData.length.toString()),
   ]);
   const payload = fileNameHeader.toString() + encoderData.toString();
   const compressedPayload = compressPayload(payload);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = {
       "process.version": '"v12.20.1"',
     }),
     new MiniCssExtractPlugin(),
-    new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/./]),
+    new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime/]),
     new HTMLInlineCSSWebpackPlugin(),
     ...(isInline ? [new HtmlInlineScriptPlugin()] : []),
   ],


### PR DESCRIPTION
## Description
Decoded files were sometimes padded by zero bytes at the end. This is an artefact of Solomon-Reed encoding requiring even sized chunks.  

- [x] File length was added to transfer header to correctly slice data buffer 
- [x] Webpack infinite HMR was fixed to ease development and testing
- [x] Various small typos in variables/function names were fixed
- [x] Percentage display fixed

## Testing notes

Testing&Troubleshooting in development was done on `mocks` branch bypassing QR code video scan. E2E should be performed with 2 machines same as ceremony on this branch on sample files that are known to have(or not have) padding after encoding.  Test files will be provided.
 
### Bash command to test resullt files
 ```bash
tail -c 200 decodong_result.json | xxd
 ```

###  ❌ Decoded File padded with zeroes 
<img width="758" alt="image" src="https://user-images.githubusercontent.com/3705803/216267806-0f454e89-ed6c-475c-a953-9dbfa9769ff6.png">

###  ✅ Correct result 
<img width="802" alt="image" src="https://user-images.githubusercontent.com/3705803/216268124-f1b4d6e2-ebcf-46f3-800a-13c6b7c787d3.png">





 